### PR TITLE
fix: correct browser export to match node export

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -10,4 +10,4 @@ const { AbortController, AbortSignal } =
 
 module.exports = AbortController
 module.exports.AbortSignal = AbortSignal
-module.exports.default = AbortController
+module.exports.AbortController = module.exports.default = AbortController


### PR DESCRIPTION
If you currently attempt to import AbortController via `const { AbortController } = require('abort-controller')`, it will work in Node but be undefined in browsers. This updates browser.js to be consistent with the exports from abort-controller.js in the dist folder.