### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# They will be requested for
+# review when someone opens a pull request.
+*       @ChainSafe/lodestar
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies md files, only md owners and not the global
+# owner(s) will be requested for a review.
+*.md    @ChainSafe/lodestar


### PR DESCRIPTION
This PR updates codeowners to Lodestar team members of the ChainSafe org for scaling purposes.